### PR TITLE
extra messages for each spec 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,20 @@ exports.config = {
 ### Additional message passing
 There is possibility to pass additional messages to report from within spec:
 
-1. Save reference to reporter object. ex.:
-<pre><code>var reporter = new HtmlScreenshotReporter({
-    filename: 'my-report.html'
-});
+1. Save reference to reporter object:
+<pre><code>var reporter = new HtmlScreenshotReporter();
 global.reporter = reporter;
 jasmine.getEnv().addReporter(reporter);</pre></code>
 
 
 2. Pass extra message
 <pre><code>describe('Top Level suite', function() {
-    it('spec', function() {
-        reporter.addMessageToSpec("Extra message");
-        expect(1).toBe(1);
-    });
-});</pre></code>
+      it('spec', function() {
+         reporter.addMessageToSpec("Extra message");
+         expect(1).toBe(1);
+      });
+});
+</pre></code>
 
 ## Options
 ### Destination directory

--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ There is possibility to pass additional messages to report from within spec:
 
 1. Save reference to reporter object. ex.:
 <pre><code>var reporter = new HtmlScreenshotReporter({
-        filename: 'my-report.html'
-    });
-    global.reporter = reporter;
-    jasmine.getEnv().addReporter(reporter);</pre></code>
+    filename: 'my-report.html'
+});
+global.reporter = reporter;
+jasmine.getEnv().addReporter(reporter);</pre></code>
 
 
 2. Pass extra message
 <pre><code>describe('Top Level suite', function() {
-        it('spec', function() {
-            reporter.addMessageToSpec("Extra message");
-            expect(1).toBe(1);
-        });
-    });</pre></code>
+    it('spec', function() {
+        reporter.addMessageToSpec("Extra message");
+        expect(1).toBe(1);
+    });
+});</pre></code>
 
 ## Options
 ### Destination directory

--- a/README.md
+++ b/README.md
@@ -30,24 +30,20 @@ exports.config = {
 There is possibility to pass additional messages to report from within spec:
 
 1. Save reference to reporter object. ex.:
-<pre><code>
-    var reporter = new HtmlScreenshotReporter({
+<pre><code>var reporter = new HtmlScreenshotReporter({
         filename: 'my-report.html'
     });
     global.reporter = reporter;
-    jasmine.getEnv().addReporter(reporter);
-</pre></code>
+    jasmine.getEnv().addReporter(reporter);</pre></code>
 
 
 2. Pass extra message
-<pre><code>
-    describe('Top Level suite', function() {
+<pre><code>describe('Top Level suite', function() {
         it('spec', function() {
             reporter.addMessageToSpec("Extra message");
             expect(1).toBe(1);
         });
-    });
-</pre></code>
+    });</pre></code>
 
 ## Options
 ### Destination directory

--- a/README.md
+++ b/README.md
@@ -26,6 +26,29 @@ exports.config = {
    }
 }</code></pre>
 
+### Additional message passing
+There is possibility to pass additional messages to report from within spec:
+
+1. Save reference to reporter object. ex.:
+<pre><code>
+    var reporter = new HtmlScreenshotReporter({
+        filename: 'my-report.html'
+    });
+    global.reporter = reporter;
+    jasmine.getEnv().addReporter(reporter);
+</pre></code>
+
+
+2. Pass extra message
+<pre><code>
+    describe('Top Level suite', function() {
+        it('spec', function() {
+            reporter.addMessageToSpec("Extra message");
+            expect(1).toBe(1);
+        });
+    });
+</pre></code>
+
 ## Options
 ### Destination directory
 

--- a/builder/templateBuilder.js
+++ b/builder/templateBuilder.js
@@ -1,0 +1,66 @@
+var _ = require('lodash');
+
+function TemplateBuilder(){
+
+    var templateString = '';
+
+    this.li = function(attrName, attrValue){
+        templateString += attrName ? '<li ' + attrName + '="' + attrValue + '">' : '<li>';
+        return this;
+    };
+
+    this.closeLi = function(){
+        templateString += '</li>';
+        return this;
+    };
+
+    this.mark = function(){
+        templateString += '<%= mark %>';
+        return this;
+    };
+
+    this.name = function(){
+        templateString += '<%= name %>';
+        return this;
+    };
+
+    this.duration = function(){
+        templateString += ' (<%= duration %> s)';
+        return this;
+    };
+
+    this.reason = function(){
+        templateString += '<%= reason %>';
+        return this;
+    };
+
+    this.additionalMessage = function(){
+        templateString += '<%= additionalMessage %>';
+        return this;
+    };
+
+    this.a = function(){
+        templateString += '<a href="<%= filename %>">';
+        return this;
+    };
+
+    this.closeA = function(){
+        templateString += '</a>';
+        return this;
+    };
+
+    this.addText = function(text){
+        templateString += text;
+        return this;
+    };
+
+    this.build = function(){
+        var template = _.template(
+            templateString
+        );
+        templateString = '';
+        return template;
+    }
+}
+
+module.exports = TemplateBuilder;


### PR DESCRIPTION
Hi! Idea is to pass extra messages from specs. Not sure if this is useful feature, but at our project we need this. And not sure if I correctly implemented it. :)

Here what you should do to pass extra message:
save reference to object

``` javascript
var reporter = new HtmlScreenshotReporter();
global.reporter = reporter;
jasmine.getEnv().addReporter(reporter);
```

use it

``` javascript
describe('Top Level suite', function() {
  it('spec', function() {
     reporter.addMessageToSpec("Extra message");
     expect(1).toBe(1);
  });
});
```

also i changed report style, please take a look at screenshot:
![screenshot](https://dl.dropboxusercontent.com/u/27207007/Public_foto/Screen%20Shot%202015-08-13%20at%2009.04.14.png)
