### PR TITLE
Always take screenshots in after.

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,6 +172,7 @@ function Jasmine2ScreenShotReporter(opts) {
     opts.pathBuilder = opts.pathBuilder || pathBuilder;
     opts.metadataBuilder = opts.metadataBuilder || metadataBuilder;
     opts.screenshotTimeout = opts.screenshotTimeout || SCREENSHOT_TIMEOUT_INTERVAL;
+    opts.specDone = opts.specDone || function(spec) {};
 
     this.jasmineStarted = function() {
         mkdirp(opts.dest, function(err) {
@@ -271,6 +272,7 @@ function Jasmine2ScreenShotReporter(opts) {
 
         if (!isSpecValid(spec)) {
           spec.skipPrinting = true;
+          opts.specDone(spec);
           return;
         }
 
@@ -298,6 +300,7 @@ function Jasmine2ScreenShotReporter(opts) {
                 throw new Error('Could not create directory for ' + screenshotPath);
             }
             writeScreenshot(spec._png, spec.filename);
+            opts.specDone(spec);
         });
     };
 


### PR DESCRIPTION
To insert the after function patch jasmine.Spec.execute.
This allows jasmine to wait until the screenshot is done.

This is not the most awesome way to do it, but since the current jasmine no longer sends the spec to "specStarted" but instead only "spec.results" we need to patch jasmine.Spec.execute to gain access to the actual spec instance.

This patch will allow:
1. jasmine will wait until the screenshot is taken.
2. jasmine specDone can now just save the already taken screenshot to a file.
3. protractor will be able to save the last failed test as a screenshot. Normally it would just blow by the last one since "specDone" has no async support and neither does "jasmineDone".
