### PR TITLE
Feature bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ This option is __enabled by default__ - it will display a summary of the test co
 
 Default is <code>true</code>
 
+### Extra configuration summary items (optional)
+
+The user may specify a set of key/value pairs that are appended to the configuration report.
+
+<pre><code>jasmine.getEnv().addReporter(new HtmlScreenshotReporter({
+   configurationStrings: {
+           "My 1st Param": firstParam,
+           "My 2nd Param": secondParam
+   }
+}));</code></pre>
+
 ### Path Builder (optional)
 
 Function used to build custom paths for screenshots. For example:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Filename for html report.
 
 Default is <code>report.html</code>
 
+### Use External CSS (optional)
+
+Array of filenames that specifies extra css files to include in the html report.
+
+<pre><code>jasmine.getEnv().addReporter(new HtmlScreenshotReporter({
+   userCss: 'my-report-styles.css'
+}));</code></pre>
+
 ### Ignore pending specs (optional)
 
 When this option is enabled, reporter will not create screenshots for pending / disabled specs. Only executed specs will be captured.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This option is __enabled by default__ - in combination with <code>captureOnlyFai
 
 ### Display summary in report (optional)
 
-This option is __enabled by default__ - it will display the total number of specs and the number of failed specs in a short summary.
+This option is __enabled by default__ - it will display the total number of specs and the number of failed specs in a short summary at the beginnning of the report.
 
 <pre><code>jasmine.getEnv().addReporter(new HtmlScreenshotReporter({
    showSummary: true

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ This option is __enabled by default__ - in combination with <code>captureOnlyFai
    captureOnlyFailedSpecs: true
 }));</code></pre>
 
+### Display summary in report (optional)
+
+This option is __enabled by default__ - it will display the total number of specs and the number of failed specs in a short summary.
+
+<pre><code>jasmine.getEnv().addReporter(new HtmlScreenshotReporter({
+   showSummary: true
+}));</code></pre>
+
+Default is <code>true</code>
+
 ### Path Builder (optional)
 
 Function used to build custom paths for screenshots. For example:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ This option is __enabled by default__ - it will display the total number of spec
 
 Default is <code>true</code>
 
+### Display links to failed specs in report summary (optional)
+
+If this option is enabled with the report summary, it will display a link to each failed spec as a part of the short summary at the beginnning of the report.
+
+<pre><code>jasmine.getEnv().addReporter(new HtmlScreenshotReporter({
+   showSummary: true,
+   showQuickLinks: true
+}));</code></pre>
+
+Default is <code>false</code>
+
 ### Display configuration summary in report (optional)
 
 This option is __enabled by default__ - it will display a summary of the test configuration details at the end of the report.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ This option is __enabled by default__ - it will display the total number of spec
 
 Default is <code>true</code>
 
+### Display configuration summary in report (optional)
+
+This option is __enabled by default__ - it will display a summary of the test configuration details at the end of the report.
+
+<pre><code>jasmine.getEnv().addReporter(new HtmlScreenshotReporter({
+   showConfiguration: true
+}));</code></pre>
+
+Default is <code>true</code>
+
 ### Path Builder (optional)
 
 Function used to build custom paths for screenshots. For example:

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ This option is __enabled by default__ - it will display a summary of the test co
 
 Default is <code>true</code>
 
+### Report title (optional)
+
+This option will add a title to the report.
+
+<pre><code>jasmine.getEnv().addReporter(new HtmlScreenshotReporter({
+   reportTitle: "Report Title"
+}));</code></pre>
+
+Default is <code>'Report'</code>
+
 ### Extra configuration summary items (optional)
 
 The user may specify a set of key/value pairs that are appended to the configuration report.

--- a/index.js
+++ b/index.js
@@ -346,7 +346,7 @@ function Jasmine2ScreenShotReporter(opts) {
         suite.isPrinted = true;
 
         output += '<ul style="list-style-type:none">';
-        output += '<h4>' + suite.fullName + ' (' + getDuration(suite) + ' s)</h4>';
+        output += '<h4>' + suite.description + ' (' + getDuration(suite) + ' s)</h4>';
 
         _.each(suite._specs, function(spec) {
             spec = specs[spec.id];

--- a/index.js
+++ b/index.js
@@ -70,7 +70,10 @@ function Jasmine2ScreenShotReporter(opts) {
                 '</style>' +
                 '<%= userCss %>' +
             '</head>' +
-            '<body><%= report %></body>' +
+            '<body>' +
+            '<h1><%= title %></h1>' +
+            '<%= report %>' +
+            '</body>' +
         '</html>'
     );
 
@@ -218,6 +221,8 @@ function Jasmine2ScreenShotReporter(opts) {
     opts.browserCaps = {};
     opts.configurationStrings = opts.configurationStrings || {};
     opts.showConfiguration = opts.showConfiguration || true;
+    opts.reportTitle = opts.reportTitle || 'Report';
+
 
     this.jasmineStarted = function(suiteInfo) {
         opts.totalSpecsDefined = suiteInfo.totalSpecsDefined;
@@ -355,6 +360,7 @@ function Jasmine2ScreenShotReporter(opts) {
       fs.appendFileSync(
         opts.dest + opts.filename,
         reportTemplate({ report: output,
+                         title: opts.reportTitle,
                          userCss: cssLinks}),
         { encoding: 'utf8' },
         function(err) {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var DEFAULT_DESTINATION = 'target/screenshots';
 
 var fs     = require('fs'),
     mkdirp = require('mkdirp'),
+    rimraf = require('rimraf'),
     _      = require('lodash'),
     path   = require('path'),
     hat    = require('hat');
@@ -227,21 +228,16 @@ function Jasmine2ScreenShotReporter(opts) {
     this.jasmineStarted = function(suiteInfo) {
         opts.totalSpecsDefined = suiteInfo.totalSpecsDefined;
 
-        mkdirp(opts.dest, function(err) {
-            var files;
+        rimraf(opts.dest, function(err) {
+          if(err) {
+            throw new Error('Could not remove previous destination directory ' + opts.dest);
+          }
 
+          mkdirp(opts.dest, function(err) {
             if(err) {
-                throw new Error('Could not create directory ' + opts.dest);
+              throw new Error('Could not create directory ' + opts.dest);
             }
-
-            files = fs.readdirSync(opts.dest);
-
-            _.each(files, function(file) {
-              var filepath = opts.dest + file;
-              if (fs.statSync(filepath).isFile()) {
-                fs.unlinkSync(filepath);
-              }
-            });
+          });
         });
 
         browser.getCapabilities().then(function (capabilities) {

--- a/index.js
+++ b/index.js
@@ -216,6 +216,7 @@ function Jasmine2ScreenShotReporter(opts) {
     opts.failedSpecs = 0;
     opts.showSummary = opts.showSummary || true;
     opts.browserCaps = {};
+    opts.configurationStrings = opts.configurationStrings || {};
     opts.showConfiguration = opts.showConfiguration || true;
 
     this.jasmineStarted = function(suiteInfo) {
@@ -452,6 +453,8 @@ function Jasmine2ScreenShotReporter(opts) {
         "Javascript enabled": opts.browserCaps.javascriptEnabled,
         "Css selectors enabled": opts.browserCaps.cssSelectorsEnabled
       };
+
+      testConfiguration = _.assign(testConfiguration, opts.configurationStrings);
 
       var keys = Object.keys(testConfiguration);
       

--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ function Jasmine2ScreenShotReporter(opts) {
                     metadataPath,
                     metadata;
 
-                file = opts.pathBuilder(spec, suites, capabilities.caps_);
+                file = opts.pathBuilder(spec, suites, capabilities);
                 spec.filename = file + '.png';
 
                 screenshotPath = path.join(opts.dest, spec.filename);

--- a/index.js
+++ b/index.js
@@ -23,6 +23,12 @@ function Jasmine2ScreenShotReporter(opts) {
             passed: '<span class="passed">&#10003;</span>'
         },
 
+        statusCssClass = {
+          pending: 'pending',
+          failed:  'failed',
+          passed:  'passed'
+        },
+
         // store extra css files.
         cssLinks = [],
 
@@ -34,7 +40,7 @@ function Jasmine2ScreenShotReporter(opts) {
         };
 
     var linkTemplate = _.template(
-        '<li id="<%= id %>" class="failed">' +
+        '<li id="<%= id %>" class="<%= cssClass %>">' +
             '<%= mark %>' +
             '<a href="<%= filename %>"><%= name %></a> ' +
             '(<%= duration %> s)' +
@@ -43,7 +49,7 @@ function Jasmine2ScreenShotReporter(opts) {
     );
 
     var nonLinkTemplate = _.template(
-        '<li title="No screenshot was created for this test case." id="<%= id %>" class="passed">' +
+        '<li title="No screenshot was created for this test case." id="<%= id %>" class="<%= cssClass %>">' +
             '<%= mark %>' +
             '<%= name %> ' +
             '(<%= duration %> s)' +
@@ -327,6 +333,7 @@ function Jasmine2ScreenShotReporter(opts) {
 
       return template({
         mark:     marks[spec.status],
+        cssClass: statusCssClass[spec.status],
         id:       spec.id,
         name:     spec.fullName.replace(suiteName, '').trim(),
         reason:   printReasonsForFailure(spec),

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function Jasmine2ScreenShotReporter(opts) {
                     'span.failed { padding: 0 1em; color: red; }' +
                     'span.pending { padding: 0 1em; color: orange; }' +
                 '</style>' +
-                '<%= userCss %>' + 
+                '<%= userCss %>' +
             '</head>' +
             '<body><%= report %></body>' +
         '</html>'

--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ function Jasmine2ScreenShotReporter(opts) {
     );
 
     var summaryTemplate = _.template(
-      '<div id="summary">' +
+      '<div id="summary" class="<%= cssClass %>">' +
         '<h4>Summary</h4>' +
         '<%= summaryBody %>' +
       '</div>'
@@ -436,6 +436,7 @@ function Jasmine2ScreenShotReporter(opts) {
         "Failed specs": opts.failedSpecs
       };
 
+      var cssClass = opts.failedSpecs > 0 ? statusCssClass["failed"] : statusCssClass["passed"];
       var keys = Object.keys(summary);
       
       var summaryOutput = "";
@@ -443,7 +444,7 @@ function Jasmine2ScreenShotReporter(opts) {
         summaryOutput += objectToItemTemplate({"key": key, "value": summary[key]});
       });
 
-      return summaryTemplate({"summaryBody": summaryOutput});
+      return summaryTemplate({"summaryBody": summaryOutput, "cssClass": cssClass});
     }
     
     function printTestConfiguration() {

--- a/index.js
+++ b/index.js
@@ -235,14 +235,14 @@ function Jasmine2ScreenShotReporter(opts) {
           return;
         }
 
-        file = opts.pathBuilder(spec, suites);
-        spec.filename = file + '.png';
-
         browser.takeScreenshot().then(function (png) {
             browser.getCapabilities().then(function (capabilities) {
                 var screenshotPath,
                     metadataPath,
                     metadata;
+
+                file = opts.pathBuilder(spec, suites, capabilities.caps_);
+                spec.filename = file + '.png';
 
                 screenshotPath = path.join(opts.dest, spec.filename);
                 metadata       = opts.metadataBuilder(spec, suites, capabilities);

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ function Jasmine2ScreenShotReporter(opts) {
             failed: '<span class="failed">&#10007;</span>',
             passed: '<span class="passed">&#10003;</span>'
         },
+
+        // store extra css files.
+        cssLinks = [],
+
         // when use use fit, jasmine never calls suiteStarted / suiteDone, so make a fake one to use
         fakeFocusedSuite = {
           id: 'focused',
@@ -58,6 +62,7 @@ function Jasmine2ScreenShotReporter(opts) {
                     '.failed { padding: 0 1em; color: red; }' +
                     '.pending { padding: 0 1em; color: orange; }' +
                 '</style>' +
+                '<%= userCss %>' + 
             '</head>' +
             '<body><%= report %></body>' +
         '</html>'
@@ -160,6 +165,16 @@ function Jasmine2ScreenShotReporter(opts) {
         return getDestination() + hat() + '/';
     };
 
+    var getCssLinks = function(cssFiles) {
+        var cssLinks = '';
+
+        _.each(cssFiles, function(file) {
+            cssLinks +='<link type="text/css" rel="stylesheet" href="' + file + '">';
+        });
+
+        return cssLinks;
+    };
+
     // TODO: more options
     opts          = opts || {};
     opts.preserveDirectory = opts.preserveDirectory || false;
@@ -170,6 +185,7 @@ function Jasmine2ScreenShotReporter(opts) {
     opts.captureOnlyFailedSpecs = opts.captureOnlyFailedSpecs || false;
     opts.pathBuilder = opts.pathBuilder || pathBuilder;
     opts.metadataBuilder = opts.metadataBuilder || metadataBuilder;
+    opts.userCss = Array.isArray(opts.userCss) ?  opts.userCss : opts.userCss ? [ opts.userCss ] : [];
 
     this.jasmineStarted = function() {
         mkdirp(opts.dest, function(err) {
@@ -283,9 +299,12 @@ function Jasmine2ScreenShotReporter(opts) {
         output += printSpec(spec);
       });
 
+      var cssLinks = getCssLinks(opts.userCss);
+
       fs.appendFileSync(
         opts.dest + opts.filename,
-        reportTemplate({ report: output}),
+        reportTemplate({ report: output,
+                         userCss: cssLinks});
         { encoding: 'utf8' },
         function(err) {
             if(err) {

--- a/index.js
+++ b/index.js
@@ -304,7 +304,7 @@ function Jasmine2ScreenShotReporter(opts) {
       fs.appendFileSync(
         opts.dest + opts.filename,
         reportTemplate({ report: output,
-                         userCss: cssLinks});
+                         userCss: cssLinks}),
         { encoding: 'utf8' },
         function(err) {
             if(err) {

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function Jasmine2ScreenShotReporter(opts) {
         };
 
     var linkTemplate = _.template(
-        '<li>' +
+        '<li id="<%= id %>" class="failed">' +
             '<%= mark %>' +
             '<a href="<%= filename %>"><%= name %></a> ' +
             '(<%= duration %> s)' +
@@ -43,7 +43,7 @@ function Jasmine2ScreenShotReporter(opts) {
     );
 
     var nonLinkTemplate = _.template(
-        '<li title="No screenshot was created for this test case.">' +
+        '<li title="No screenshot was created for this test case." id="<%= id %>" class="passed">' +
             '<%= mark %>' +
             '<%= name %> ' +
             '(<%= duration %> s)' +
@@ -58,9 +58,9 @@ function Jasmine2ScreenShotReporter(opts) {
                 '<style>' +
                     'body { font-family: Arial; }' +
                     'ul { list-style-position: inside; }' +
-                    '.passed { padding: 0 1em; color: green; }' +
-                    '.failed { padding: 0 1em; color: red; }' +
-                    '.pending { padding: 0 1em; color: orange; }' +
+                    'span.passed { padding: 0 1em; color: green; }' +
+                    'span.failed { padding: 0 1em; color: red; }' +
+                    'span.pending { padding: 0 1em; color: orange; }' +
                 '</style>' +
                 '<%= userCss %>' + 
             '</head>' +
@@ -327,6 +327,7 @@ function Jasmine2ScreenShotReporter(opts) {
 
       return template({
         mark:     marks[spec.status],
+        id:       spec.id,
         name:     spec.fullName.replace(suiteName, '').trim(),
         reason:   printReasonsForFailure(spec),
         filename: encodeURIComponent(spec.filename),

--- a/index.js
+++ b/index.js
@@ -298,6 +298,10 @@ function Jasmine2ScreenShotReporter(opts) {
           return;
         }
 
+        if (spec.status === 'failed') {
+          opts.failedSpecs += 1;
+        }
+
         browser.takeScreenshot().then(function (png) {
             browser.getCapabilities().then(function (capabilities) {
                 var screenshotPath,
@@ -378,10 +382,6 @@ function Jasmine2ScreenShotReporter(opts) {
 
       if (spec.isPrinted || (spec.skipPrinting && !isSpecReportable(spec))) {
         return '';
-      }
-
-      if (spec.status === 'failed') {
-        opts.failedSpecs += 1;
       }
 
       spec.isPrinted = true;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "hat": "0.0.3",
     "lodash": "^3.0.0",
     "mkdirp": "^0.5.0",
+    "rimraf": "^2.4.3",
     "string.prototype.startswith": "^0.2.0"
   },
   "keywords": [


### PR DESCRIPTION
Hi there, 

I've put together a bunch of changes that you might be interested in.  If you need I can separate these and repackage them.  

Anyway this introduces new features:
- user specified css files
- a report title option
- pass fail summary at the top of the report
- quick links to failed tests at the top of the report
- a settings summary at the end

Changes and fixes include: 
- using 'rimraf' to empty the output directory
- using the spec description rather than full name for cleaner presentation
- reinstating the old promise resolved browser caps that is used by the pathBuilder.
