### PR TITLE
Added browserName option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,16 @@ This option is __disabled by default__. When this option is enabled, than for ea
    preserveDirectory: true
 }));</code></pre>
  
+### Browser Name (optional)
+
+Option is used in the report to separate each browser suites when using 'multiCapabilities'.
+
+<pre><code>onPrepare: function() {
+  return browser.getProcessedConfig().then(function(config) {
+    jasmine.getEnv().addReporter(new HtmlScreenshotReporter({ 
+      browserName : config.capabilities.browserName
+    }););
+  });
+}</code></pre>
+
+Default don't print the specific line.

--- a/index.js
+++ b/index.js
@@ -170,6 +170,7 @@ function Jasmine2ScreenShotReporter(opts) {
     opts.captureOnlyFailedSpecs = opts.captureOnlyFailedSpecs || false;
     opts.pathBuilder = opts.pathBuilder || pathBuilder;
     opts.metadataBuilder = opts.metadataBuilder || metadataBuilder;
+    opts.browserName = opts.browserName || '';
 
     this.jasmineStarted = function() {
         mkdirp(opts.dest, function(err) {
@@ -274,6 +275,11 @@ function Jasmine2ScreenShotReporter(opts) {
           // focused spec (fit) -- suiteDone was never called
           self.suiteDone(fakeFocusedSuite);
       }
+
+      if (opts.browserName) {
+        output += printBrowserName();
+      }
+
       _.each(suites, function(suite) {
         output += printResults(suite);
       });
@@ -342,6 +348,10 @@ function Jasmine2ScreenShotReporter(opts) {
         output += '</ul>';
 
         return output;
+    }
+
+    function printBrowserName() {
+      return '<h3>' + opts.browserName + '</h3>';
     }
 
     function printReasonsForFailure(spec) {


### PR DESCRIPTION
I'm running tests with Protractor with multiple browsers. And the report doesn't show which browser a suite belongs.
For that, I add a simple text option allowing to add a h3 title to the test suites.

Orignal idea was to put the browser name, but you could imagine whatever you want (OS, version, ...)
