### PR TITLE
Fixes to allow use with parallel specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ If the directory doesn't exist, it will be created automatically or otherwise cl
    dest: '/project/test/screenshots'
 }));</code></pre>
 
+### Clean destination directory (optional)
+
+This option is __enabled by default__. Toggle whether or not to remove and rebuild destination when jasmine starts.
+
+This is useful when you are running protractor tests in parallel, and wish all of the processes to report to the same directory.
+
+When cleanDestination is set to true, it is recommended that you disabled showSummary and showConfiguration, and set reportTitle to null. If you do not, the report will be pretty cluttered.
+
+<pre><code>jasmine.getEnv().addReporter(new HtmlScreenshotReporter({
+   cleanDestination: false,
+   showSummary: false,
+   showConfiguration: false,
+   reportTitle: null
+}));</code></pre>
+
+
 ### Filename (optional)
 
 Filename for html report.
@@ -166,8 +182,7 @@ By default, the runner builder will not save any metadata except the actual html
 
 This option is __disabled by default__. When this option is enabled, than for each report will be
  created separate directory with unique name. Directory unique name will be generated randomly.
- 
+
 <pre><code>jasmine.getEnv().addReporter(new HtmlScreenshotReporter({
    preserveDirectory: true
 }));</code></pre>
- 

--- a/index.js
+++ b/index.js
@@ -219,6 +219,20 @@ function Jasmine2ScreenShotReporter(opts) {
         return cssLinks;
     };
 
+    var cleanDestination = function() {
+        rimraf(opts.dest, function(err) {
+          if(err) {
+            throw new Error('Could not remove previous destination directory ' + opts.dest);
+          }
+
+          mkdirp(opts.dest, function(err) {
+            if(err) {
+              throw new Error('Could not create directory ' + opts.dest);
+            }
+          });
+        });
+    };
+
     // TODO: more options
     opts          = opts || {};
     opts.preserveDirectory = opts.preserveDirectory || false;
@@ -238,21 +252,14 @@ function Jasmine2ScreenShotReporter(opts) {
     opts.configurationStrings = opts.configurationStrings || {};
     opts.showConfiguration = opts.hasOwnProperty('showConfiguration') ? opts.showConfiguration : true;
     opts.reportTitle = opts.hasOwnProperty('reportTitle') ? opts.reportTitle : 'Report';
+    opts.cleanDestination = opts.hasOwnProperty('cleanDestination') ? opts.cleanDestination : true;
 
     this.jasmineStarted = function(suiteInfo) {
         opts.totalSpecsDefined = suiteInfo.totalSpecsDefined;
 
-        rimraf(opts.dest, function(err) {
-          if(err) {
-            throw new Error('Could not remove previous destination directory ' + opts.dest);
-          }
-
-          mkdirp(opts.dest, function(err) {
-            if(err) {
-              throw new Error('Could not create directory ' + opts.dest);
-            }
-          });
-        });
+        if (opts.cleanDestination) {
+            cleanDestination();
+        }
 
         browser.getCapabilities().then(function (capabilities) {
             opts.browserCaps.browserName = capabilities.get('browserName');

--- a/index.js
+++ b/index.js
@@ -232,13 +232,12 @@ function Jasmine2ScreenShotReporter(opts) {
     opts.userCss = Array.isArray(opts.userCss) ?  opts.userCss : opts.userCss ? [ opts.userCss ] : [];
     opts.totalSpecsDefined = null;
     opts.failedSpecs = 0;
-    opts.showSummary = opts.showSummary || true;
+    opts.showSummary = opts.hasOwnProperty('showSummary') ? opts.showSummary : true;
     opts.showQuickLinks = opts.showQuickLinks || false;
     opts.browserCaps = {};
     opts.configurationStrings = opts.configurationStrings || {};
-    opts.showConfiguration = opts.showConfiguration || true;
-    opts.reportTitle = opts.reportTitle || 'Report';
-
+    opts.showConfiguration = opts.hasOwnProperty('showConfiguration') ? opts.showConfiguration : true;
+    opts.reportTitle = opts.hasOwnProperty('reportTitle') ? opts.reportTitle : 'Report';
 
     this.jasmineStarted = function(suiteInfo) {
         opts.totalSpecsDefined = suiteInfo.totalSpecsDefined;


### PR DESCRIPTION
Adding a couple fixes and documentation that allow folks to use this reporter when running protractor specs in parallel.

The individual commit messages have more detailed descriptions of what was changed and why.

Fixes #36 

Fixes #37
