### PR TITLE
Fix for report summary when running on sharded/multicapability config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,20 @@ In your Protractor configuration file, register protractor-jasmine2-screenshot-r
 
 <pre><code>var HtmlScreenshotReporter = require('protractor-jasmine2-screenshot-reporter');
 
+var reporter = new HtmlScreenshotReporter({
+  dest: 'target/screenshots',
+  filename: 'my-report.html'
+});  
+
 exports.config = {
    // ...
 
+   beforeLaunch: function() {
+      reporter.beforeLaunch(); 
+   }
+
    onPrepare: function() {
-      jasmine.getEnv().addReporter(
-        new HtmlScreenshotReporter({
-          dest: 'target/screenshots',
-          filename: 'my-report.html'
-        })
-      );
+      jasmine.getEnv().addReporter(reporter);
    }
 }</code></pre>
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ If the directory doesn't exist, it will be created automatically or otherwise cl
    dest: '/project/test/screenshots'
 }));</code></pre>
 
+### Clean destination directory (optional)
+
+This option is __enabled by default__. Toggle whether or not to remove and rebuild destination when jasmine starts.
+
+This is useful when you are running protractor tests in parallel, and wish all of the processes to report to the same directory.
+
+When cleanDestination is set to true, it is recommended that you disabled showSummary and showConfiguration, and set reportTitle to null. If you do not, the report will be pretty cluttered.
+
+<pre><code>jasmine.getEnv().addReporter(new HtmlScreenshotReporter({
+   cleanDestination: false,
+   showSummary: false,
+   showConfiguration: false,
+   reportTitle: null
+}));</code></pre>
+
+
 ### Filename (optional)
 
 Filename for html report.
@@ -166,8 +182,7 @@ By default, the runner builder will not save any metadata except the actual html
 
 This option is __disabled by default__. When this option is enabled, than for each report will be
  created separate directory with unique name. Directory unique name will be generated randomly.
- 
+
 <pre><code>jasmine.getEnv().addReporter(new HtmlScreenshotReporter({
    preserveDirectory: true
 }));</code></pre>
- 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The <code>protractor-jasmine2-screenshot-reporter</code> is available via npm:
 In your Protractor configuration file, register protractor-jasmine2-screenshot-reporter in jasmine:
 
 <pre><code>var HtmlScreenshotReporter = require('protractor-jasmine2-screenshot-reporter');
+var protractor = require('protractor');        
 
 var reporter = new HtmlScreenshotReporter({
   dest: 'target/screenshots',
@@ -21,12 +22,29 @@ var reporter = new HtmlScreenshotReporter({
 exports.config = {
    // ...
 
+   // Setup the report before any tests start
    beforeLaunch: function() {
-      reporter.beforeLaunch(); 
-   }
+      var deferred = protractor.promise.defer();
+      reporter.beforeLaunch(function() {
+        deferred.fulfill();
+      }, 500); 
 
+      return deferred.promise;
+   },
+
+   // Assign the test reporter to each running instance
    onPrepare: function() {
       jasmine.getEnv().addReporter(reporter);
+   },
+
+   // Close the report after all tests finish
+   afterLaunch: function(exitCode) {
+      var deferred = protractor.promise.defer();
+      reporter.afterLaunch(function() {
+        deferred.fulfill(exitCode);
+      }, 500);
+
+      return deferred.promise;
    }
 }</code></pre>
 

--- a/index.js
+++ b/index.js
@@ -266,27 +266,28 @@ function Jasmine2ScreenShotReporter(opts) {
     opts.cleanDestination = opts.hasOwnProperty('cleanDestination') ? opts.cleanDestination : true;
 
     this.beforeLaunch = function(callback) {
+      console.log('Report destination:  ', path.join(opts.dest, opts.filename));
       var cssLinks = getCssLinks(opts.userCss);
       
       if (opts.cleanDestination) {
         cleanDestination(function(err) {
-            opts.dest + opts.filename,
           fs.appendFile(
+            path.join(opts.dest, opts.filename),
             openReportTemplate({ userCss: cssLinks}),
             { encoding: 'utf8' },
             function(err) {
               if(err) {
-                console.error('Error writing to file:' + opts.dest + opts.filename);
+                console.error('Error writing to file:' + path.join(opts.dest, opts.filename));
                 throw err;
               }
               if (opts.reportTitle) {
                 fs.appendFile(
-                  opts.dest + opts.filename,
+                  path.join(opts.dest, opts.filename),
                   addReportTitle({ title: opts.reportTitle}),
                   { encoding: 'utf8' },
                   function(err) {
                     if(err) {
-                      console.error('Error writing to file:' + opts.dest + opts.filename);
+                      console.error('Error writing to file:' + path.join(opts.dest, opts.filename));
                       throw err;
                     }
                     callback();
@@ -300,14 +301,15 @@ function Jasmine2ScreenShotReporter(opts) {
     };
 
     this.afterLaunch = function(callback) {
+      console.log('Closing report');
 
       fs.appendFile(
-        opts.dest + opts.filename,
+        path.join(opts.dest, opts.filename),
         closeReportTemplate(),
         { encoding: 'utf8' },
         function(err) {
           if(err) {
-            console.error('Error writing to file:' + opts.dest + opts.filename);
+            console.error('Error writing to file:' + path.join(opts.dest, opts.filename));
             throw err;
           }
           callback();
@@ -436,12 +438,12 @@ function Jasmine2ScreenShotReporter(opts) {
 
 
       fs.appendFileSync(
-        opts.dest + opts.filename,
+        path.join(opts.dest, opts.filename),
         reportTemplate({ report: output }),
         { encoding: 'utf8' },
         function(err) {
             if(err) {
-              console.error('Error writing to file:' + opts.dest + opts.filename);
+              console.error('Error writing to file:' + path.join(opts.dest, opts.filename));
               throw err;
             }
         }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var fs     = require('fs'),
     rimraf = require('rimraf'),
     _      = require('lodash'),
     path   = require('path'),
+    uuid   = require('uuid'),
     hat    = require('hat');
 
 require('string.prototype.startswith');
@@ -73,6 +74,12 @@ function Jasmine2ScreenShotReporter(opts) {
                     'span.pending { padding: 0 1em; color: orange; }' +
                 '</style>' +
                 '<%= userCss %>' +
+                '<script type="text/javascript">' +
+                  'function showhide(id) {' +
+                    'var e = document.getElementById(id);' +
+                    'e.style.display = (e.style.display == "block") ? "none" : "block";' +
+                  '}' +
+                '</script>' +
             '</head>' +
             '<body>'
     );
@@ -107,7 +114,10 @@ function Jasmine2ScreenShotReporter(opts) {
     );
 
     var configurationTemplate = _.template(
-      '<div id="config">' +
+      '<a href="javascript:showhide(\'<%= configId %>\')">' +
+        'Toggle Configuration' +
+      '</a>' +
+      '<div class="config" id="<%= configId %>" style="display: none">' +
         '<h4>Configuration</h4>' +
         '<%= configBody %>' +
       '</div>'
@@ -555,7 +565,8 @@ function Jasmine2ScreenShotReporter(opts) {
         configOutput += objectToItemTemplate({"key": key, "value": testConfiguration[key]});
       });
 
-      return configurationTemplate({"configBody": configOutput});
+      var configId = uuid.v1();
+      return configurationTemplate({"configBody": configOutput, "configId": configId});
     }
 
     return this;

--- a/index.js
+++ b/index.js
@@ -313,11 +313,14 @@ function Jasmine2ScreenShotReporter(opts) {
       console.log('Report destination:  ', path.join(opts.dest, opts.filename));
 
       var cssLinks = getCssLinks(opts.userCss);
+      var summaryQuickLinks = opts.showQuickLinks ? addQuickLinks(): '';
+      var reportSummary = opts.showSummary ? addReportSummary({ quickLinks: summaryQuickLinks }) : '';
+
 
       // Now you'll need to build the replacement report text for the file.
       var reportContent = openReportTemplate({ userCss: cssLinks});
       reportContent += addReportTitle({ title: opts.reportTitle});
-      reportContent += addReportSummary({ quickLinks: addQuickLinks()});
+      reportContent += reportSummary;
 
       // Now remove the existing stored content and replace it with the new report shell.
       cleanDestination(function(err) {

--- a/index.js
+++ b/index.js
@@ -268,6 +268,12 @@ function Jasmine2ScreenShotReporter(opts) {
     };
 
     var cleanDestination = function(callback) {
+        // if we aren't removing the old report folder then simply return
+        if (!opts.cleanDestination) {
+          callback();
+          return;
+        }
+        
         rimraf(opts.dest, function(err) {
           if(err) {
             throw new Error('Could not remove previous destination directory ' + opts.dest);
@@ -305,12 +311,6 @@ function Jasmine2ScreenShotReporter(opts) {
 
     this.beforeLaunch = function(callback) {
       console.log('Report destination:  ', path.join(opts.dest, opts.filename));
-
-      // if we aren't removing the old report folder then simply return
-      if (!cleanDestination) {
-        callback();
-        return;
-      }
 
       var cssLinks = getCssLinks(opts.userCss);
 

--- a/index.js
+++ b/index.js
@@ -463,8 +463,17 @@ function Jasmine2ScreenShotReporter(opts) {
         output += printSpec(spec);
       });
 
+      // Add configuration information when requested and only if specs have been reported.
       if (opts.showConfiguration) {
-        output += printTestConfiguration();
+        var suiteHasSpecs = false;
+        
+        _.each(specs, function(spec) {
+          suiteHasSpecs = spec.isPrinted || suiteHasSpecs;
+        });
+
+        if (suiteHasSpecs) {
+          output += printTestConfiguration();
+        }
       }
 
       fs.appendFileSync(

--- a/index.js
+++ b/index.js
@@ -31,9 +31,6 @@ function Jasmine2ScreenShotReporter(opts) {
           passed:  'passed'
         },
 
-        // store extra css files.
-        cssLinks = [],
-
         // monitor failed specs for quick links
         failedSpecIds = [],
 

--- a/index.js
+++ b/index.js
@@ -290,6 +290,7 @@ function Jasmine2ScreenShotReporter(opts) {
                 console.error('Error writing to file:' + path.join(opts.dest, opts.filename));
                 throw err;
               }
+          
               if (opts.reportTitle) {
                 fs.appendFile(
                   path.join(opts.dest, opts.filename),
@@ -303,6 +304,8 @@ function Jasmine2ScreenShotReporter(opts) {
                     callback();
                   }
                 );
+              } else {
+                callback();
               }
             }
           );

--- a/index.js
+++ b/index.js
@@ -219,6 +219,20 @@ function Jasmine2ScreenShotReporter(opts) {
         return cssLinks;
     };
 
+    var cleanDestination = function() {
+        rimraf(opts.dest, function(err) {
+          if(err) {
+            throw new Error('Could not remove previous destination directory ' + opts.dest);
+          }
+
+          mkdirp(opts.dest, function(err) {
+            if(err) {
+              throw new Error('Could not create directory ' + opts.dest);
+            }
+          });
+        });
+    };
+
     // TODO: more options
     opts          = opts || {};
     opts.preserveDirectory = opts.preserveDirectory || false;
@@ -238,21 +252,14 @@ function Jasmine2ScreenShotReporter(opts) {
     opts.configurationStrings = opts.configurationStrings || {};
     opts.showConfiguration = opts.hasOwnProperty('showConfiguration') ? opts.showConfiguration : true;
     opts.reportTitle = opts.hasOwnProperty('reportTitle') ? opts.reportTitle : 'Report';
+    opts.cleanDestination = opts.hasOwnProperty('cleanDestination') ? opts.cleanDestination : true;
 
     this.jasmineStarted = function(suiteInfo) {
         opts.totalSpecsDefined = suiteInfo.totalSpecsDefined;
 
-        rimraf(opts.dest, function(err) {
-          if(err) {
-            throw new Error('Could not remove previous destination directory ' + opts.dest);
-          }
-
-          mkdirp(opts.dest, function(err) {
-            if(err) {
-              throw new Error('Could not create directory ' + opts.dest);
-            }
-          });
-        });
+        if (opts.cleanDestination) {
+            cleanDestination();
+        }
 
         browser.getCapabilities().then(function (capabilities) {
             opts.browserCaps.browserName = capabilities.get('browserName');

--- a/index.js
+++ b/index.js
@@ -232,13 +232,12 @@ function Jasmine2ScreenShotReporter(opts) {
     opts.userCss = Array.isArray(opts.userCss) ?  opts.userCss : opts.userCss ? [ opts.userCss ] : [];
     opts.totalSpecsDefined = null;
     opts.failedSpecs = 0;
-    opts.showSummary = opts.showSummary || true;
+    opts.showSummary = opts.hasOwnProperty('showSummary') ? opts.showSummary : true;
     opts.showQuickLinks = opts.showQuickLinks || false;
     opts.browserCaps = {};
     opts.configurationStrings = opts.configurationStrings || {};
-    opts.showConfiguration = opts.showConfiguration || true;
-    opts.reportTitle = opts.reportTitle || 'Report';
-
+    opts.showConfiguration = opts.hasOwnProperty('showConfiguration') ? opts.showConfiguration : true;
+    opts.reportTitle = opts.hasOwnProperty('reportTitle') ? opts.reportTitle : 'Report';
 
     this.jasmineStarted = function(suiteInfo) {
         opts.totalSpecsDefined = suiteInfo.totalSpecsDefined;

--- a/index.js
+++ b/index.js
@@ -254,12 +254,14 @@ function Jasmine2ScreenShotReporter(opts) {
     opts.reportTitle = opts.hasOwnProperty('reportTitle') ? opts.reportTitle : 'Report';
     opts.cleanDestination = opts.hasOwnProperty('cleanDestination') ? opts.cleanDestination : true;
 
+    this.beforeLaunch = function() {
+        if (opts.cleanDestination) {
+          cleanDestination();
+        }
+    };
+
     this.jasmineStarted = function(suiteInfo) {
         opts.totalSpecsDefined = suiteInfo.totalSpecsDefined;
-
-        if (opts.cleanDestination) {
-            cleanDestination();
-        }
 
         browser.getCapabilities().then(function (capabilities) {
             opts.browserCaps.browserName = capabilities.get('browserName');

--- a/index.js
+++ b/index.js
@@ -265,13 +265,13 @@ function Jasmine2ScreenShotReporter(opts) {
     opts.reportTitle = opts.hasOwnProperty('reportTitle') ? opts.reportTitle : 'Report';
     opts.cleanDestination = opts.hasOwnProperty('cleanDestination') ? opts.cleanDestination : true;
 
-    this.beforeLaunch = function() {
+    this.beforeLaunch = function(callback) {
       var cssLinks = getCssLinks(opts.userCss);
       
       if (opts.cleanDestination) {
         cleanDestination(function(err) {
-          fs.appendFileSync(
             opts.dest + opts.filename,
+          fs.appendFile(
             openReportTemplate({ userCss: cssLinks}),
             { encoding: 'utf8' },
             function(err) {
@@ -279,29 +279,29 @@ function Jasmine2ScreenShotReporter(opts) {
                 console.error('Error writing to file:' + opts.dest + opts.filename);
                 throw err;
               }
+              if (opts.reportTitle) {
+                fs.appendFile(
+                  opts.dest + opts.filename,
+                  addReportTitle({ title: opts.reportTitle}),
+                  { encoding: 'utf8' },
+                  function(err) {
+                    if(err) {
+                      console.error('Error writing to file:' + opts.dest + opts.filename);
+                      throw err;
+                    }
+                    callback();
+                  }
+                );
+              }
             }
           );
-
-          if (opts.reportTitle) {
-            fs.appendFileSync(
-              opts.dest + opts.filename,
-              addReportTitle({ title: opts.reportTitle}),
-              { encoding: 'utf8' },
-              function(err) {
-                if(err) {
-                  console.error('Error writing to file:' + opts.dest + opts.filename);
-                  throw err;
-                }
-              }
-            );
-          }
         });
       }
     };
 
-    this.onComplete = function() {
+    this.afterLaunch = function(callback) {
 
-      fs.appendFileSync(
+      fs.appendFile(
         opts.dest + opts.filename,
         closeReportTemplate(),
         { encoding: 'utf8' },
@@ -310,6 +310,7 @@ function Jasmine2ScreenShotReporter(opts) {
             console.error('Error writing to file:' + opts.dest + opts.filename);
             throw err;
           }
+          callback();
         }
       );
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-jasmine2-screenshot-reporter",
-  "version": "0.2.0",
+  "version": "0.3.0-0",
   "description": "Use the screenshot reporter to capture screenshots after each executed Protractor test case.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lodash": "^3.0.0",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.4.3",
-    "string.prototype.startswith": "^0.2.0"
+    "string.prototype.startswith": "^0.2.0",
+    "uuid": "^2.0.0"
   },
   "keywords": [
     "screenshot",


### PR DESCRIPTION
Hi there,

I've spent a bit of time trying to get this to run in sharded mode.  It seems good in my tests with the exception of when a shard fails completely nothing will be reported.  Anyway it builds on the corrections of chogan, requires changes to the conf file to run various async set up functions bookending the protractor run test suites and embeds a little more js into the report to establish the report summary and quicklinks.  

So let me know what you think and whether any modifications are needed.

Regards,
Andrew
