### PR TITLE
Feature/add more tests

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -63,6 +63,22 @@ describe('Jasmine2ScreenShotReporter tests', function(){
     });
   });
 
+  it('beforeLaunch should add custom CSS', function(done){
+    var reporter = new Jasmine2ScreenShotReporter({
+      dest: destinationPath,
+      filename: reportFileName,
+      userCss: 'myCSSFile.css'});
+
+    assert.equal(typeof reporter.beforeLaunch, 'function'); //Public method beforeLaunch should be defined
+
+    reporter.beforeLaunch(function() {
+      var contents = fs.readFileSync(destinationPath + '/' + reportFileName, 'utf8');
+      expect(contents).to.contain('<link type="text/css" rel="stylesheet" href="myCSSFile.css">');
+      done();
+    });
+  });
+
+
   it('afterLaunch should close down report', function(done){
     var reporter = new Jasmine2ScreenShotReporter({
       dest: destinationPath,
@@ -93,10 +109,9 @@ describe('Jasmine2ScreenShotReporter tests', function(){
     done();
   });
 
-  it('report is being generated', function(done){
+  it('report is being generated for failed', function(done){
 
     //@TODO: Need to elaborate this test.
-
     var reporter = new Jasmine2ScreenShotReporter({
         dest: destinationPath,
         filename: reportFileName});
@@ -114,9 +129,8 @@ describe('Jasmine2ScreenShotReporter tests', function(){
     setTimeout(function(){
       reporter.suiteStarted({description : 'mockSuiteDescription', fullName: 'mockSuiteFullName'});
       reporter.specStarted({description : 'mockSpecDescription', fullName: 'mockSpecFullName'});
-      reporter.specDone({description : 'mockSpecDescription', fullName: 'mockSpecFullName',
-        failedExpectations: [{message: 'mockFailedMessage', stack: 'mockStackMessage'}],
-        passedExpectations: [{message: 'mockPassedMessage'}]
+      reporter.specDone({description : 'mockSpecDescription', fullName: 'mockSpecFullName', status: 'failed',
+        failedExpectations: [{message: 'mockFailedMessage', stack: 'mockStackMessage'}]
       });
 
       reporter.suiteDone({description : 'mockSuiteDescription', fullName: 'mockSuiteFullName'});
@@ -129,6 +143,8 @@ describe('Jasmine2ScreenShotReporter tests', function(){
         expect(contents).to.contain('<li>Platform:  platformmockValue</li>');
         expect(contents).to.contain('<li>Javascript enabled:  javascriptEnabledmockValue</li>');
         expect(contents).to.contain('<li>Css selectors enabled:  cssSelectorsEnabledmockValue</li>');
+        expect(contents).to.contain('mockFailedMessage');
+        expect(contents).to.contain('mockStackMessage');
         done();
       });
 
@@ -144,7 +160,7 @@ describe('Jasmine2ScreenShotReporter tests', function(){
     rimraf(destinationPath, function(err) {
       if(err) {
         console.error('Could not delete ' + destinationPath + 'directory');
-      }
+     }
       done();
     });
   });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -29,8 +29,8 @@ describe('Jasmine2ScreenShotReporter tests', function(){
     global.browser =  {
       getCapabilities: function () {
         var p = Promise.resolve(
-          {capabilities: {
-            get: function() {return 'mockValue';}
+          { get: function(el) {
+              return el + 'mockValue';
           }}
         );
         return p;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -34,6 +34,10 @@ describe('Jasmine2ScreenShotReporter tests', function(){
           }}
         );
         return p;
+      },
+      takeScreenshot: function() {
+        var p = Promise.resolve('mockJPGImage');
+        return p;
       }
     };
   });
@@ -104,22 +108,35 @@ describe('Jasmine2ScreenShotReporter tests', function(){
     assert.equal(typeof reporter.jasmineDone , 'function'); //Public method suiteDone should be defined
 
     fs.writeFileSync(destinationPath + '/' + reportFileName, ''); //create empty report file
+    reporter.jasmineStarted(suiteInfo);
 
-    reporter.suiteStarted({description : 'mockSuiteDescription', fullName: 'mockSuiteFullName'});
-    reporter.specStarted({description : 'mockSpecDescription', fullName: 'mockSpecFullName'});
-    reporter.specDone({description : 'mockSpecDescription', fullName: 'mockSpecFullName',
-      failedExpectations: [{message: 'mockFailedMessage', stack: 'mockStackMessage'}],
-      passedExpectations: [{message: 'mockPassedMessage'}]
-    });
+    //setTimeout is needed because jasmineStarted contain promise that need to be fullfilled
+    setTimeout(function(){
+      reporter.suiteStarted({description : 'mockSuiteDescription', fullName: 'mockSuiteFullName'});
+      reporter.specStarted({description : 'mockSpecDescription', fullName: 'mockSpecFullName'});
+      reporter.specDone({description : 'mockSpecDescription', fullName: 'mockSpecFullName',
+        failedExpectations: [{message: 'mockFailedMessage', stack: 'mockStackMessage'}],
+        passedExpectations: [{message: 'mockPassedMessage'}]
+      });
 
-    reporter.suiteDone({description : 'mockSuiteDescription', fullName: 'mockSuiteFullName'});
-    reporter.jasmineDone();
-    fs.readFile(destinationPath + '/' + reportFileName, 'utf8', function(error, contents) {
+      reporter.suiteDone({description : 'mockSuiteDescription', fullName: 'mockSuiteFullName'});
+      reporter.jasmineDone();
+      fs.readFile(destinationPath + '/' + reportFileName, 'utf8', function(error, contents) {
+        expect(contents).to.contain('<h4>mockSuiteDescription');
+        expect(contents).to.contain('mockSpecFullName');
+        expect(contents).to.contain('<li>Jasmine version:  mockJasmineVersion</li>');
+        expect(contents).to.contain('<li>Browser name:  browserNamemockValue</li>');
+        expect(contents).to.contain('<li>Platform:  platformmockValue</li>');
+        expect(contents).to.contain('<li>Javascript enabled:  javascriptEnabledmockValue</li>');
+        expect(contents).to.contain('<li>Css selectors enabled:  cssSelectorsEnabledmockValue</li>');
+        done();
+      });
 
-      expect(contents).to.contain('<h4>mockSuiteDescription');
-      expect(contents).to.contain('mockSpecFullName');
-      done();
-    });
+
+    }, 1);
+
+
+
   });
 
   afterEach(function(done) {


### PR DESCRIPTION
Further development of automatic tests to cover browser output as well.
I had to use setTimeout (with 1 millisecond) to enable jasmineStarted  inner function to resolve promise (The promise is not depend on external resources) before continuing to suiteStarted.
Right now the test coverage is above 80% in lines, functions and statements but ~60% in branches.
