### PR TITLE
	Create the screenshot directory even if nothing writes a screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ This is to include the browser type in the generated image file
 Filename for html report.
 
 <pre><code>jasmine.getEnv().addReporter(new HtmlScreenshotReporter({
-   filename: 'my-report.html'
+  browserName: config.capabilities.browserName,
+
 }));</code></pre>
 
 Default is <code>report.html</code>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ exports.config = {
         new HtmlScreenshotReporter({
           dest: 'target/screenshots',
           filename: 'my-report.html'
+          browserName: config.capabilities.browserName,
+
         })
       );
    }
@@ -39,6 +41,15 @@ If the directory doesn't exist, it will be created automatically or otherwise cl
 
 ### Filename (optional)
 
+Filename for html report.
+
+<pre><code>jasmine.getEnv().addReporter(new HtmlScreenshotReporter({
+   filename: 'my-report.html'
+}));</code></pre>
+
+### browserName  (optional)
+
+This is to include the browser type in the generated image file
 Filename for html report.
 
 <pre><code>jasmine.getEnv().addReporter(new HtmlScreenshotReporter({

--- a/index.js
+++ b/index.js
@@ -236,7 +236,7 @@ function Jasmine2ScreenShotReporter(opts) {
         }
 
         file = opts.pathBuilder(spec, suites);
-        spec.filename = file + '.png';
+        spec.filename =  spec.fullName+'.png';
 
         browser.takeScreenshot().then(function (png) {
             browser.getCapabilities().then(function (capabilities) {

--- a/index.js
+++ b/index.js
@@ -272,17 +272,22 @@ function Jasmine2ScreenShotReporter(opts) {
         output += printSpec(spec);
       });
 
-      fs.appendFileSync(
-        opts.dest + opts.filename,
-        reportTemplate({ report: output}),
-        { encoding: 'utf8' },
-        function(err) {
-            if(err) {
-              console.error('Error writing to file:' + opts.dest + opts.filename);
-              throw err;
+      mkdirp(path.dirname(opts.dest + opts.filename), function (err) {
+          if(err) {
+              throw new Error('Could not create directory: ' + err);
+          }
+          fs.appendFileSync(
+            opts.dest + opts.filename,
+            reportTemplate({ report: output}),
+            { encoding: 'utf8' },
+            function(err) {
+                if(err) {
+                  console.error('Error writing to file:' + opts.dest + opts.filename);
+                  throw err;
+                }
             }
-        }
-      );
+          );
+      });
     };
 
     function printSpec(spec) {

--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ function Jasmine2ScreenShotReporter(opts) {
 
     // write data into opts.dest as filename
     var writeScreenshot = function (data, filename) {
+    console.log('writing screenshot')
         var stream = fs.createWriteStream(opts.dest + filename);
         stream.write(new Buffer(data, 'base64'));
         stream.end();
@@ -235,40 +236,15 @@ function Jasmine2ScreenShotReporter(opts) {
           spec.skipPrinting = true;
           return;
         }
-
         file = opts.pathBuilder(spec, suites);
-        spec.filename =  opts.browserName+'_'+spec.fullName+'.png';
-
+        var cleanSpec = spec.fullName.replace(/[^a-zA-Z ]/g, "");
+        var maxChar = 250 - 50 - opts.dest.length;
+        spec.filename =  opts.browserName+'_'+cleanSpec.substring(0,maxChar)+'.png';
         browser.takeScreenshot().then(function (png) {
-            browser.getCapabilities().then(function (capabilities) {
-                var screenshotPath,
-                    metadataPath,
-                    metadata;
-
-                screenshotPath = path.join(opts.dest, spec.filename);
-                metadata       = opts.metadataBuilder(spec, suites, capabilities);
-
-                if (metadata) {
-                    metadataPath = path.join(opts.dest, file + '.json');
-                    mkdirp(path.dirname(metadataPath), function(err) {
-                        if(err) {
-                            throw new Error('Could not create directory for ' + metadataPath);
-                        }
-                        writeMetadata(metadata, metadataPath);
-                    });
-                }
-
-                mkdirp(path.dirname(screenshotPath), function(err) {
-                    if(err) {
-                        throw new Error('Could not create directory for ' + screenshotPath);
-                    }
-                    writeScreenshot(png, spec.filename);
-                });
+             writeScreenshot(png, spec.filename);
             });
-        });
-    };
-
-    this.jasmineDone = function() {
+        };
+      this.jasmineDone = function() {
       var output = '';
 
       if (runningSuite) {
@@ -357,3 +333,4 @@ function Jasmine2ScreenShotReporter(opts) {
 }
 
 module.exports = Jasmine2ScreenShotReporter;
+

--- a/index.js
+++ b/index.js
@@ -164,10 +164,11 @@ function Jasmine2ScreenShotReporter(opts) {
     opts          = opts || {};
     opts.preserveDirectory = opts.preserveDirectory || false;
     opts.dest     = opts.preserveDirectory ?  getDestinationWithUniqueDirectory() : getDestination();
-    opts.filename = opts.filename || 'report.html';
+    opts.filename = opts.filename || 'reportScreenshots.html';
     opts.ignoreSkippedSpecs = opts.ignoreSkippedSpecs || false;
     opts.reportOnlyFailedSpecs = opts.hasOwnProperty('reportOnlyFailedSpecs') ? opts.reportOnlyFailedSpecs : true;
     opts.captureOnlyFailedSpecs = opts.captureOnlyFailedSpecs || false;
+    opts.browserName = opts.browserName;
     opts.pathBuilder = opts.pathBuilder || pathBuilder;
     opts.metadataBuilder = opts.metadataBuilder || metadataBuilder;
 
@@ -236,7 +237,7 @@ function Jasmine2ScreenShotReporter(opts) {
         }
 
         file = opts.pathBuilder(spec, suites);
-        spec.filename =  spec.fullName+'.png';
+        spec.filename =  opts.browserName+'_'+spec.fullName+'.png';
 
         browser.takeScreenshot().then(function (png) {
             browser.getCapabilities().then(function (capabilities) {

--- a/index.js
+++ b/index.js
@@ -241,8 +241,20 @@ function Jasmine2ScreenShotReporter(opts) {
         var maxChar = 250 - 50 - opts.dest.length;
         spec.filename =  opts.browserName+'_'+cleanSpec.substring(0,maxChar)+'.png';
         browser.takeScreenshot().then(function (png) {
-             writeScreenshot(png, spec.filename);
-            });
+          browser.getCapabilities().then(function (capabilities) {
+		  var screenshotPath = path.join(opts.dest, spec.filename);
+
+				 mkdirp(path.dirname(screenshotPath), function(err) {
+                     if(err) {
+                       throw new Error('Could not create directory for ' + screenshotPath);
+                    }
+                    writeScreenshot(png, spec.filename);
+
+			     });
+          });
+        });
+
+
         };
       this.jasmineDone = function() {
       var output = '';


### PR DESCRIPTION
due error

ENOENT: no such file or directory, open 'target/screenshots/report.html'
[chrome ANY #01-2]     at Error (native)
[chrome ANY #01-2]     at Object.fs.openSync (fs.js:640:18)
[chrome ANY #01-2]     at Object.fs.writeFileSync (fs.js:1333:33)
[chrome ANY #01-2]     at Object.fs.appendFileSync (fs.js:1392:6)
[chrome ANY #01-2]     at Jasmine2ScreenShotReporter.jasmineDone (/var/lib/jenkins/workspace/PerModulePipeline-GavinTest/unified-analytics/node_modules/protractor-jasmine2-screenshot-reporter/index.js:500:10)
[chrome ANY #01-2]     at dispatch (/var/lib/jenkins/workspace/PerModulePipeline-GavinTest/unified-analytics/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1966:28)
[chrome ANY #01-2]     at ReportDispatcher.jasmineDone (/var/lib/jenkins/workspace/PerModulePipeline-GavinTest/unified-analytics/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1949:11)
[chrome ANY #01-2]     at /var/lib/jenkins/workspace/PerModulePipeline-GavinTest/unified-analytics/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:758:18
[chrome ANY #01-2]     at QueueRunner.clearStack (/var/lib/jenkins/workspace/PerModulePipeline-GavinTest/unified-analytics/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:660:9)
[chrome ANY #01-2]     at QueueRunner.run (/var/lib/jenkins/workspace/PerModulePipeline-GavinTest/unified-analytics/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1881:12)
