### PR TITLE
increase lodash dependency version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "hat": "0.0.3",
-    "lodash": "^3.0.0",
+    "lodash": ">=3 <5",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.4.3",
     "string.prototype.startswith": "^0.2.0",


### PR DESCRIPTION
Lodash v3 is no longer supported, and it looks like v4 does not introduce any breaking changes for this package.

Can we increase the range of the supported lodash dependency to include v4 as proposed in this PR?

This would avoid unmet peer dependency warnings on npm install when using a supported version of lodash.
