### PR TITLE
Add support for optional inline images in report

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,16 @@ This option is __disabled by default__. When this option is enabled, than for ea
   preserveDirectory: true
 });</code></pre>
 
+### Inline Images (optional)
+
+Produce images inline in the report instead of links.
+
+<pre><code>var reporter = new HtmlScreenshotReporter({
+  inlineImages: true
+});</code></pre>
+
+Default is <code>false</code>
+
 ## Forked browser instances
 
 The reporter can take screenshots also from instances forked off the main browser.

--- a/index.js
+++ b/index.js
@@ -55,6 +55,23 @@ function Jasmine2ScreenShotReporter(opts) {
       '</li>'
   );
 
+  var inlineTemplate = _.template(
+      '<li id="<%= id %>" ' +
+      'class="<%= cssClass %>" ' +
+      'data-spec="<%= specId %>" ' +
+      'data-name="<%= name %>" ' +
+      'data-browser="<%= browserName %>">' +
+      '<%= mark %>' +
+      '<img src="<%= filename[\'main\'] %>"><%= name %></img>' +
+      '<% _.forEach(filename, function (val, key) { if (key != \'main\') { %>' +
+      ' [<img src="<%= val %>"><%= key %></img>] ' +
+      '<% } }) %>' +
+      '(<%= duration %> s)' +
+      '<%= reason %>' +
+      '<%= failedUrl %>' +
+      '</li>'
+  );
+
   var nonLinkTemplate = _.template(
       '<li title="No screenshot was created for this test case." ' +
       'id="<%= id %>" ' +
@@ -327,6 +344,7 @@ function Jasmine2ScreenShotReporter(opts) {
   opts.reportTitle = opts.hasOwnProperty('reportTitle') ? opts.reportTitle : 'Report';
   opts.cleanDestination = opts.hasOwnProperty('cleanDestination') ? opts.cleanDestination : true;
   opts.reportFailedUrl = opts.reportFailedUrl || false;
+  opts.inlineImages = opts.inlineImages || false;
 
   // TODO: proper nesting -> no need for magic
 
@@ -371,7 +389,7 @@ function Jasmine2ScreenShotReporter(opts) {
 
   function printSpec(spec) {
     var suiteName = spec._suite ? spec._suite.fullName : '';
-    var template = !_.isEmpty(spec.filename) ? linkTemplate : nonLinkTemplate;
+    var template = !_.isEmpty(spec.filename) ? (opts.inlineImages ? inlineTemplate : linkTemplate) : nonLinkTemplate;
 
     if (spec.isPrinted || (spec.skipPrinting && !isSpecReportable(spec))) {
       return '';


### PR DESCRIPTION
A quick fix for supporting inline images in the report.
Had a plan to support some width/height scaling as well on the <img> tag but my template skills are a bit lacking. I'll do it if you want though.
 