### PR TITLE
Ensure directory is created before trying to write report file

### DIFF
--- a/index.js
+++ b/index.js
@@ -635,18 +635,23 @@ function Jasmine2ScreenShotReporter(opts) {
         output += printTestConfiguration();
       }
     }
-
-    fs.appendFileSync(
-        path.join(opts.dest, opts.filename),
-        reportTemplate({ report: output }),
-        { encoding: 'utf8' },
-        function(err) {
-          if(err) {
-            console.error('Error writing to file:' + path.join(opts.dest, opts.filename));
-            throw err;
+    mkdirp(path.dirname(opts.dest + opts.filename), function (err) {
+      if (err) {
+        console.log('Error creating screenshot directory');
+        throw err;
+      }
+      fs.appendFileSync(
+          path.join(opts.dest, opts.filename),
+          reportTemplate({ report: output }),
+          { encoding: 'utf8' },
+          function(err) {
+            if(err) {
+              console.error('Error writing to file:' + path.join(opts.dest, opts.filename));
+              throw err;
+            }
           }
-        }
-    );
+      );
+    });
   };
 
   return this;


### PR DESCRIPTION
This is the same basic fix from https://github.com/mlison/protractor-jasmine2-screenshot-reporter/pull/74 and should resolve https://github.com/mlison/protractor-jasmine2-screenshot-reporter/issues/65. Since the previous PR wasn't going to get rebased I just figured I'd create a new one.