### PR TITLE
Include disabled specs as skipped

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,7 +255,7 @@ function Jasmine2ScreenShotReporter(opts) {
 
   var isSpecValid = function(spec) {
     // Don't screenshot skipped specs
-    var isSkipped = opts.ignoreSkippedSpecs && spec.status === 'pending';
+    var isSkipped = opts.ignoreSkippedSpecs && (spec.status === 'pending' || spec.status === 'disabled');
     // Screenshot only for failed specs
     var isIgnored = opts.captureOnlyFailedSpecs && spec.status !== 'failed';
 


### PR DESCRIPTION
The README says
> When this option is enabled, reporter will not create screenshots for pending / disabled specs. Only executed specs will be captured.

https://github.com/mlison/protractor-jasmine2-screenshot-reporter#ignore-pending-specs-optional

Currently this behavior is not true, screenshots are taken for disabled specs.  This should address that bug.